### PR TITLE
Add cross platform CI build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "json-stream-js",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "json-stream-js",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@napi-rs/cli": "^2.18.4"
+      }
+    },
+    "node_modules/@napi-rs/cli": {
+      "version": "2.18.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.18.4.tgz",
+      "integrity": "sha512-SgJeA4df9DE2iAEpr3M2H0OKl/yjtg1BnRI5/JyowS71tUWhrfSu2LT0V3vlHET+g1hBVlrO60PmEXwUEKp8Mg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi": "scripts/index.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,12 +4,19 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "cargo build --release && cp target/release/libjson_stream_js.so index.node",
-    "test": "npm run build && node test/test.js"
+    "build": "npx napi build --release",
+    "test": "npm run build && node test/test.js",
+    "prepublishOnly": "npx napi build --release --platform"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
-  "devDependencies": {}
+  "files": [
+    "index.js",
+    "index.*.node"
+  ],
+  "devDependencies": {
+    "@napi-rs/cli": "^2.18.4"
+  }
 }


### PR DESCRIPTION
## Summary
- enable building and testing on Linux, macOS and Windows
- switch to `@napi-rs/cli` for building native module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686b79f59aec8324aed3679b88157ed4