### PR TITLE
Add metadata for npm

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # Packaging TODO
 
-1. **Add metadata for npm publication**
+1. **Add metadata for npm publication** ✅
    - Update `package.json` with description, keywords, repository URL, author, and license fields.
    - Ensure `main` points to `index.js` which loads the compiled binary.
 

--- a/package.json
+++ b/package.json
@@ -1,15 +1,25 @@
 {
   "name": "json-stream-js",
   "version": "1.0.0",
-  "description": "",
+  "description": "Node.js bindings for json-stream-parser",
   "main": "index.js",
   "scripts": {
     "build": "cargo build --release && cp target/release/libjson_stream_js.so index.node",
     "test": "npm run build && node test/test.js"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "json",
+    "stream",
+    "parser",
+    "napi",
+    "rust"
+  ],
+  "author": "json-stream contributors",
+  "license": "MIT",
   "type": "commonjs",
-  "devDependencies": {}
+  "devDependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/json-stream/json-stream-js"
+  }
 }


### PR DESCRIPTION
## Summary
- add repository metadata to package.json
- mark TODO item 1 as complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b800296108324b967703f637c51e8