### PR TITLE
Implement build system for prebuilt binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ version = "0.1.0"
 dependencies = [
  "json-stream-parser",
  "napi",
+ "napi-build",
  "napi-derive",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "json-stream-js"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [lib]
 crate-type = ["cdylib"]
@@ -14,4 +15,7 @@ json-stream-parser = "0.1.5"
 napi = { version = "3.0.0-beta.12", features = ["napi4", "serde-json"] }
 napi-derive = "3.0.0-beta.12"
 serde_json = "1"
+
+[build-dependencies]
+napi-build = "2"
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
    - Update `package.json` with description, keywords, repository URL, author, and license fields.
    - Ensure `main` points to `index.js` which loads the compiled binary.
 
-2. **Introduce a build system for prebuilt binaries**
+2. **Introduce a build system for prebuilt binaries** 🚧
    - Use `@napi-rs/cli` or a similar tool to compile the Rust code into Node prebuilds.
    - Configure builds for Node 16, 18, and 20 on Linux, macOS, and Windows.
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Node.js bindings for json-stream-parser",
   "main": "index.js",
   "scripts": {
-    "build": "cargo build --release && cp target/release/libjson_stream_js.so index.node",
+    "build": "NAPI_TYPE_DEF_TMP_FOLDER=./napi npx @napi-rs/cli build --release",
+    "build:platform": "NAPI_TYPE_DEF_TMP_FOLDER=./napi npx @napi-rs/cli build --platform",
     "test": "npm run build && node test/test.js"
   },
   "keywords": [
@@ -17,7 +18,9 @@
   "author": "json-stream contributors",
   "license": "MIT",
   "type": "commonjs",
-  "devDependencies": {},
+  "devDependencies": {
+    "@napi-rs/cli": "^2.18.4"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/json-stream/json-stream-js"


### PR DESCRIPTION
## Summary
- mark the build system task as in progress
- add `@napi-rs/cli` dev dependency
- use `napi` build scripts for release and platform builds
- configure Cargo to use napi-build via build.rs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb0da76f883248be9662a18573777